### PR TITLE
Fix for Client.set_permissions() issue

### DIFF
--- a/pyxs/client.py
+++ b/pyxs/client.py
@@ -225,7 +225,7 @@ class Client(object):
         payload = self.execute_command(Op.GET_PERMS, path)
         return payload.split("\x00")
 
-    def set_permissions(self, path, perms):
+    def set_permissions(self, path, *perms):
         """Sets a access permissions for a given `path`, see
         :exc:`~pyxs.exceptions.InvalidPermission` for details on
         permission format.


### PR DESCRIPTION
> > > import pyxs
> > > xsc = pyxs.Client(xen_bus_path="/proc/xen/xenbus")
> > > xsc.mkdir("/some/path")
> > > xsc.set_permissions("/some/path", 'r0')

would raise:
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/root/.local/lib/python2.7/site-packages/pyxs-0.3-py2.7.egg/pyxs/client.py", line 227, in set_permissions
    self.ack(Op.SET_PERMS, path, _perms)
  File "/root/.local/lib/python2.7/site-packages/pyxs-0.3-py2.7.egg/pyxs/client.py", line 154, in ack
    if self.execute_command(_args) != "OK":
  File "/root/.local/lib/python2.7/site-packages/pyxs-0.3-py2.7.egg/pyxs/client.py", line 116, in execute_command
    if not self.COMMAND_VALIDATORS.get(op, lambda _args: True)(_args):
  File "/root/.local/lib/python2.7/site-packages/pyxs-0.3-py2.7.egg/pyxs/client.py", line 68, in <lambda>
    lambda p, *perms: validate_path(p) and validate_perms(perms)),
  File "/root/.local/lib/python2.7/site-packages/pyxs-0.3-py2.7.egg/pyxs/helpers.py", line 154, in validate_perms
    raise InvalidPermission(perm)
pyxs.exceptions.InvalidPermission: r

With this change:

> > > xsc.set_permissions("/some/path", 'r0', 'w0')

works correctly and verifying the results with xenstore-ls -p shows:
some  = "" . . . . . . . . . . . . . . . . . . . . . . . .  (n0)
 path = "" . . . . . . . . . . . . . . . . . . . . . . . .  (r0,w0)
