### PR TITLE
Windows Xenstore Support

### DIFF
--- a/pyxs/_internal.py
+++ b/pyxs/_internal.py
@@ -22,7 +22,7 @@ from .exceptions import InvalidOperation, InvalidPayload
 
 #: Operations supported by XenStore.
 Operations = Op = namedtuple("Operations", [
-    "DEBUG",
+    "CONTROL",
     "DIRECTORY",
     "READ",
     "GET_PERMS",

--- a/pyxs/client.py
+++ b/pyxs/client.py
@@ -108,12 +108,8 @@ class Client(object):
             self.tx_id = self.transaction_start()
 
     def __enter__(self):
-            try:
-                self.connection.connect()
-            except wmi.x_wmi:
-                raise PyXSError, None, sys.exc_info()[2]
-            return self
-
+        self.connection.connect()
+        return self
 
     def __exit__(self, *exc_info):
         if not any(exc_info) and self.tx_id:
@@ -458,4 +454,3 @@ class Monitor(object):
 
             if sleep is not None:
                 time.sleep(sleep)
-

--- a/pyxs/client.py
+++ b/pyxs/client.py
@@ -92,7 +92,16 @@ class Client(object):
         elif os.name in ["nt"]:
             import wmi
             c = wmi.WMI()
-            for system in c.Win32_OperatingSystem():
+            try:
+            	win32_os = c.Win32_OperatingSystem()
+            except wmi.x_wmi:
+                sleep(0.5)
+                try:
+            	    win32_os = c.Win32_OperatingSystem()
+                except wmi.x_wmi:
+                    raise PyXSError()
+
+            for system in win32_os:
                 if re.match('Microsoft Windows Server 2008.*', system.caption):
                     self.connection = XenBusConnectionWin2008()
                 else:

--- a/pyxs/client.py
+++ b/pyxs/client.py
@@ -454,7 +454,7 @@ class Monitor(object):
             # Executing a noop, hopefuly we'll get some events queued
             # in the meantime. Note: I know it sucks, but it seems like
             # there's no other way ...
-            self.client.execute_command(Op.CONTROL, "check")
+            self.client.execute_command(Op.CONTROL, "noop")
 
             if sleep is not None:
                 time.sleep(sleep)

--- a/pyxs/client.py
+++ b/pyxs/client.py
@@ -25,6 +25,7 @@ import threading
 import time
 import posixpath
 import os
+from time import sleep
 from collections import deque
 
 from ._internal import Event, Packet, Op

--- a/pyxs/client.py
+++ b/pyxs/client.py
@@ -108,8 +108,12 @@ class Client(object):
             self.tx_id = self.transaction_start()
 
     def __enter__(self):
-        self.connection.connect()
-        return self
+            try:
+                self.connection.connect()
+            except wmi.x_wmi:
+                raise PyXSError, None, sys.exc_info()[2]
+            return self
+
 
     def __exit__(self, *exc_info):
         if not any(exc_info) and self.tx_id:
@@ -454,3 +458,4 @@ class Monitor(object):
 
             if sleep is not None:
                 time.sleep(sleep)
+

--- a/pyxs/client.py
+++ b/pyxs/client.py
@@ -454,7 +454,7 @@ class Monitor(object):
             # Executing a noop, hopefuly we'll get some events queued
             # in the meantime. Note: I know it sucks, but it seems like
             # there's no other way ...
-            self.client.execute_command(Op.DEBUG, "")
+            self.client.execute_command(Op.CONTROL, "check")
 
             if sleep is not None:
                 time.sleep(sleep)

--- a/pyxs/client.py
+++ b/pyxs/client.py
@@ -121,7 +121,13 @@ class Client(object):
 
         with self.tx_lock:
             kwargs["tx_id"] = self.tx_id  # Forcing ``tx_id`` here.
-            self.connection.send(Packet(op, "".join(args), **kwargs))
+            if op in [Op.WRITE]:
+                # xenstore will write the trailing \x00 of the value
+                # for writes so trim it for behaviour equivalent to
+                # xenstore-write
+                self.connection.send(Packet(op, "".join(args)[:-1], **kwargs))
+            else:
+                self.connection.send(Packet(op, "".join(args), **kwargs))
 
             # If we have any watched paths `XenStore` will send watch
             # events mixed with replies to other operations, so we loop

--- a/pyxs/client.py
+++ b/pyxs/client.py
@@ -24,6 +24,7 @@ import re
 import threading
 import time
 import posixpath
+import os
 from collections import deque
 
 from ._internal import Event, Packet, Op
@@ -85,9 +86,11 @@ class Client(object):
                  xen_bus_path=None, connection=None, transaction=None):
         if connection:
             self.connection = connection
-        elif unix_socket_path or not xen_bus_path:
+        elif os.name in ["posix"] and (unix_socket_path or not xen_bus_path):
             self.connection = UnixSocketConnection(
                 unix_socket_path, socket_timeout=socket_timeout)
+        elif os.name in ["nt"]:
+            self.connection = XenBusConnectionWin()
         else:
             self.connection = XenBusConnection(xen_bus_path)
 

--- a/pyxs/client.py
+++ b/pyxs/client.py
@@ -28,7 +28,7 @@ import os
 from collections import deque
 
 from ._internal import Event, Packet, Op
-from .connection import UnixSocketConnection, XenBusConnection
+from .connection import UnixSocketConnection, XenBusConnection, XenBusConnectionWin
 from .exceptions import UnexpectedPacket, PyXSError
 from .helpers import validate_path, validate_watch_path, validate_perms, \
     dict_merge, force_unicode, error

--- a/pyxs/client.py
+++ b/pyxs/client.py
@@ -94,11 +94,11 @@ class Client(object):
             import wmi
             c = wmi.WMI()
             try:
-            	win32_os = c.Win32_OperatingSystem()
+                win32_os = c.Win32_OperatingSystem()
             except wmi.x_wmi:
                 sleep(0.5)
                 try:
-            	    win32_os = c.Win32_OperatingSystem()
+                    win32_os = c.Win32_OperatingSystem()
                 except wmi.x_wmi:
                     raise PyXSError()
 

--- a/pyxs/client.py
+++ b/pyxs/client.py
@@ -29,7 +29,7 @@ from time import sleep
 from collections import deque
 
 from ._internal import Event, Packet, Op
-from .connection import UnixSocketConnection, XenBusConnection, XenBusConnectionWin, XenBusConnectionWin2008
+from .connection import UnixSocketConnection, XenBusConnection, XenBusConnectionWinWINPV, XenBusConnectionWinGPLPV
 from .exceptions import UnexpectedPacket, PyXSError
 from .helpers import validate_path, validate_watch_path, validate_perms, \
     dict_merge, force_unicode, error
@@ -104,9 +104,9 @@ class Client(object):
 
             for system in win32_os:
                 if re.match('Microsoft Windows Server 2008.*', system.caption):
-                    self.connection = XenBusConnectionWin2008()
+                    self.connection = XenBusConnectionWinGPLPV()
                 else:
-                    self.connection = XenBusConnectionWin()
+                    self.connection = XenBusConnectionWinWINPV()
         else:
             self.connection = XenBusConnection(xen_bus_path)
 

--- a/pyxs/client.py
+++ b/pyxs/client.py
@@ -25,7 +25,6 @@ import threading
 import time
 import posixpath
 import os
-from time import sleep
 from collections import deque
 
 from ._internal import Event, Packet, Op

--- a/pyxs/connection.py
+++ b/pyxs/connection.py
@@ -233,7 +233,7 @@ class XenBusConnectionWin(FileDescriptorConnection):
                 _wmiSession = wmi.WMI(moniker="//./root/wmi", find_classes=False)
             xenStoreBase = _wmiSession.XenProjectXenStoreBase()[0]
         except: # WMI can raise all sorts of exceptions
-            if retry > 20:
+            if retry < 20:
                 sleep(5)
                 self.connect(retry=(retry+1))
                 return

--- a/pyxs/connection.py
+++ b/pyxs/connection.py
@@ -14,6 +14,7 @@ from __future__ import absolute_import, unicode_literals
 
 __all__ = ["UnixSocketConnection", "XenBusConnection", "XenBusConnectionWin", "XenBusConnectionWin2008"]
 
+import logging
 import errno
 import os
 import platform
@@ -245,9 +246,9 @@ class XenBusConnectionWin(FileDescriptorConnection):
         if len(sessions) <= 0:
             session_name = "PyxsSession"
             session_id = xenStoreBase.AddSession(Id=session_name)[0]
-            self.session = _wmiSession.query("select * from XenProjectXenStoreSession where SessionId = {id}".format(id=session_id))
-        else:
-            self.session = sessions.pop()
+            sessions = _wmiSession.query("select * from XenProjectXenStoreSession where SessionId = {id}".format(id=session_id))
+
+        self.session = sessions.pop()
 
 
     # Emulate sending the packet directly to the XenStore interface
@@ -256,7 +257,7 @@ class XenBusConnectionWin(FileDescriptorConnection):
         global _wmiSession
 
         try:
-            if not _wmiSession:
+            if not _wmiSession or not self.session:
                 self.connect()
         except wmi.x_wmi:
             raise PyXSError, None, sys.exc_info()[2]

--- a/pyxs/connection.py
+++ b/pyxs/connection.py
@@ -12,7 +12,7 @@
 
 from __future__ import absolute_import, unicode_literals
 
-__all__ = ["UnixSocketConnection", "XenBusConnection", "XenBusConnectionWin", "XenBusConnectionWin2008"]
+__all__ = ["UnixSocketConnection", "XenBusConnection", "XenBusConnectionWinWINPV", "XenBusConnectionWinGPLPV"]
 
 import logging
 import errno
@@ -210,7 +210,7 @@ class XenBusConnection(FileDescriptorConnection):
 
 _wmiSession = None
 
-class XenBusConnectionWin(FileDescriptorConnection):
+class XenBusConnectionWinWINPV(FileDescriptorConnection):
     session = None
     response_packet = None
 
@@ -313,7 +313,7 @@ class XenBusConnectionWin(FileDescriptorConnection):
 
 _winDevicePath = None
 
-class XenBusConnectionWin2008(FileDescriptorConnection):
+class XenBusConnectionWinGPLPV(FileDescriptorConnection):
     def __init__(self):
         global _winDevicePath
 

--- a/pyxs/connection.py
+++ b/pyxs/connection.py
@@ -36,7 +36,7 @@ if os.name in ["nt"]:
 if sys.version_info[0] is not 3:
     bytes, str = str, unicode
 
-from .exceptions import ConnectionError
+from .exceptions import ConnectionError, WindowsDriverError
 from .helpers import writeall, readall, osnmopen, osnmclose, osnmread
 from ._internal import Packet
 
@@ -258,17 +258,17 @@ get_xen_interface_path()
         # Return code checkers
         def ValidHandle(value, func, arguments):
             if value == 0:
-                raise ctypes.WinError()
+                raise WindowsDriverError(str(ctypes.WinError()))
             return value
 
         def ValidEnum(value, func, arguments):
             if value != ERROR_NO_MORE_ITEMS:
-                raise ctypes.WinError()
+                raise WindowsDriverError(str(ctypes.WinError()))
             return value
 
         def ValidSdid(value, func, arguments):
             if value != ERROR_INSUFFICIENT_BUFFER:
-                raise ctypes.WinError()
+                raise WindowsDriverError(str(ctypes.WinError()))
             return value
 
         # Some structures used by the Windows API

--- a/pyxs/connection.py
+++ b/pyxs/connection.py
@@ -123,10 +123,6 @@ class FileDescriptorConnection(object):
             return Packet(op, payload, rq_id, tx_id)
 
 
-    def __del__(self):
-        self.disconnect()
-
-
 class UnixSocketConnection(FileDescriptorConnection):
     """XenStore connection through Unix domain socket.
 

--- a/pyxs/connection.py
+++ b/pyxs/connection.py
@@ -184,7 +184,7 @@ class XenBusConnection(FileDescriptorConnection):
             system = platform.system()
 
             if system == "Linux":
-                path = "/proc/xen/xenbus"
+                path = "/dev/xen/xenbus" if os.path.exists("/dev/xen/xenbus") else "/proc/xen/xenbus"
             elif system == "NetBSD":
                 path = "/kern/xen/xenbus"
             else:

--- a/pyxs/connection.py
+++ b/pyxs/connection.py
@@ -23,7 +23,6 @@ import sys
 from time import sleep
 from ._internal import Packet, Op
 sys.coinit_flags = 0
-import pythoncom
 
 if os.name in ["nt"]:
     import wmi
@@ -39,7 +38,6 @@ if os.name in ["nt"]:
     from ctypes.wintypes import HKEY
     from ctypes.wintypes import BYTE
     sys.coinit_flags = 0
-    import pythoncom
 
 if sys.version_info[0] is not 3:
     bytes, str = str, unicode

--- a/pyxs/connection.py
+++ b/pyxs/connection.py
@@ -228,12 +228,12 @@ class XenBusConnectionWin(FileDescriptorConnection):
     
         # Create a WMI Session
         try:
-            if not _wmiSession:
+            if not _wmiSession or retry:
                 _wmiSession = wmi.WMI(moniker="//./root/wmi", find_classes=False)
             xenStoreBase = _wmiSession.XenProjectXenStoreBase()[0]
         except wmi.x_wmi:
             if not retry:
-                _wmiSession = None
+                #_wmiSession = None
                 self.connect(retry=True)
                 return
             else: raise
@@ -461,4 +461,3 @@ class XenBusConnectionWin2008(FileDescriptorConnection):
         except Exception as e:
              raise ConnectionError("Error while opening {0!r}: {1}"
                                   .format(self.path, e.args))
-

--- a/pyxs/connection.py
+++ b/pyxs/connection.py
@@ -234,7 +234,7 @@ class XenBusConnectionWin(FileDescriptorConnection):
             xenStoreBase = _wmiSession.XenProjectXenStoreBase()[0]
         except: # WMI can raise all sorts of exceptions
             if not retry:
-                sleep(0.5)
+                sleep(5)
                 self.connect(retry=True)
                 return
             else: raise

--- a/pyxs/connection.py
+++ b/pyxs/connection.py
@@ -208,47 +208,8 @@ class XenBusConnectionWin(FileDescriptorConnection):
     def __init__(self):
         # Determine self.path using some magic Windows code which is derived from
         # http://pydoc.net/Python/pyserial/2.6/serial.tools.list_ports_windows/.
-        # The equivalent C from The GPLPV driver source is:
-        """\
-DEFINE_GUID(GUID_XENBUS_IFACE, 0x14ce175a, 0x3ee2, 0x4fae, 0x92, 0x52, 0x0, 0xdb, 0xd8, 0x4f, 0x1, 0x8e);
-
-static char *
-get_xen_interface_path()
-{
-  HDEVINFO handle;
-  SP_DEVICE_INTERFACE_DATA sdid;
-  SP_DEVICE_INTERFACE_DETAIL_DATA *sdidd;
-  DWORD buf_len;
-  char *path;
-
-  handle = SetupDiGetClassDevs(&GUID_XENBUS_IFACE, 0, NULL, DIGCF_PRESENT | DIGCF_DEVICEINTERFACE);
-  if (handle == INVALID_HANDLE_VALUE)
-  {
-    printf("SetupDiGetClassDevs failed\n");
-    return NULL;
-  }
-  sdid.cbSize = sizeof(sdid);
-  if (!SetupDiEnumDeviceInterfaces(handle, NULL, &GUID_XENBUS_IFACE, 0, &sdid))
-  {
-    printf("SetupDiEnumDeviceInterfaces failed\n");
-    return NULL;
-  }
-  SetupDiGetDeviceInterfaceDetail(handle, &sdid, NULL, 0, &buf_len, NULL);
-  sdidd = malloc(buf_len);
-  sdidd->cbSize = sizeof(SP_DEVICE_INTERFACE_DETAIL_DATA);
-  if (!SetupDiGetDeviceInterfaceDetail(handle, &sdid, sdidd, buf_len, NULL, NULL))
-  {
-    printf("SetupDiGetDeviceInterfaceDetail failed\n");
-    return NULL;
-  }
-
-  path = malloc(strlen(sdidd->DevicePath) + 1);
-  StringCbCopyA(path, strlen(sdidd->DevicePath) + 1, sdidd->DevicePath);
-  free(sdidd);
-
-  return path;
-}
-"""
+        # The equivalent C from The GPLPV driver source can be found in get_xen_interface_path() of shutdownmon.
+        # - http://xenbits.xensource.com/ext/win-pvdrivers/file/896402519f15/shutdownmon/shutdownmon.c
         DIGCF_PRESENT = 2
         DIGCF_DEVICEINTERFACE = 16
         NULL = None

--- a/pyxs/connection.py
+++ b/pyxs/connection.py
@@ -123,6 +123,10 @@ class FileDescriptorConnection(object):
             return Packet(op, payload, rq_id, tx_id)
 
 
+    def __del__(self):
+        self.disconnect()
+
+
 class UnixSocketConnection(FileDescriptorConnection):
     """XenStore connection through Unix domain socket.
 
@@ -205,7 +209,7 @@ class XenBusConnectionWin(FileDescriptorConnection):
         # Determine self.path using some magic Windows code which is derived from
         # http://pydoc.net/Python/pyserial/2.6/serial.tools.list_ports_windows/.
         # The equivalent C from The GPLPV driver source is:
-"""
+        """\
 DEFINE_GUID(GUID_XENBUS_IFACE, 0x14ce175a, 0x3ee2, 0x4fae, 0x92, 0x52, 0x0, 0xdb, 0xd8, 0x4f, 0x1, 0x8e);
 
 static char *
@@ -248,26 +252,20 @@ get_xen_interface_path()
         DIGCF_PRESENT = 2
         DIGCF_DEVICEINTERFACE = 16
         NULL = None
+        ERROR_SUCCESS = 0
         ERROR_INSUFFICIENT_BUFFER = 122
         ERROR_NO_MORE_ITEMS = 259
 
         HDEVINFO = ctypes.c_void_p
+        PCTSTR = ctypes.c_char_p
+        CHAR = ctypes.c_char
         PDWORD = ctypes.POINTER(DWORD)
         LPDWORD = ctypes.POINTER(DWORD)
+        PULONG = ctypes.POINTER(ULONG)
 
         # Return code checkers
         def ValidHandle(value, func, arguments):
             if value == 0:
-                raise ctypes.WinError()
-            return value
-
-        def ValidEnum(value, func, arguments):
-            if value != ERROR_NO_MORE_ITEMS:
-                raise ctypes.WinError()
-            return value
-
-        def ValidSdid(value, func, arguments):
-            if value != ERROR_INSUFFICIENT_BUFFER:
                 raise ctypes.WinError()
             return value
 
@@ -294,7 +292,7 @@ get_xen_interface_path()
                 ('cbSize', DWORD),
                 ('ClassGuid', GUID),
                 ('DevInst', DWORD),
-                ('Reserved', ULONG_PTR),
+                ('Reserved', PULONG),
             ]
 
             def __str__(self):
@@ -306,7 +304,7 @@ get_xen_interface_path()
                 ('cbSize', DWORD),
                 ('InterfaceClassGuid', GUID),
                 ('Flags', DWORD),
-                ('Reserved', ULONG_PTR),
+                ('Reserved', PULONG),
             ]
 
             def __str__(self):
@@ -326,12 +324,10 @@ get_xen_interface_path()
         SetupDiEnumDeviceInterfaces = setupapi.SetupDiEnumDeviceInterfaces
         SetupDiEnumDeviceInterfaces.argtypes = [HDEVINFO, PSP_DEVINFO_DATA, ctypes.POINTER(GUID), DWORD, PSP_DEVICE_INTERFACE_DATA]
         SetupDiEnumDeviceInterfaces.restype = BOOL
-        SetupDiEnumDeviceInterfaces.errcheck = ValidEnum
 
         SetupDiGetDeviceInterfaceDetail = setupapi.SetupDiGetDeviceInterfaceDetailA
         SetupDiGetDeviceInterfaceDetail.argtypes = [HDEVINFO, PSP_DEVICE_INTERFACE_DATA, PSP_DEVICE_INTERFACE_DETAIL_DATA, DWORD, PDWORD, PSP_DEVINFO_DATA]
         SetupDiGetDeviceInterfaceDetail.restype = BOOL
-        SetupDiGetDeviceInterfaceDetail.errcheck = ValidSdid
 
         SetupDiDestroyDeviceInfoList = setupapi.SetupDiDestroyDeviceInfoList
         SetupDiDestroyDeviceInfoList.argtypes = [HDEVINFO]
@@ -340,14 +336,18 @@ get_xen_interface_path()
         # Do stuff
         GUID_XENBUS_IFACE = GUID(0x14ce175aL, 0x3ee2, 0x4fae, (BYTE*8)(0x92, 0x52, 0x0, 0xdb, 0xd8, 0x4f, 0x1, 0x8e))
 
-        handle = SetupDiGetClassDevs(ctypes.byref(GUID_XENBUS_IFACE), 0, NULL, DIGCF_PRESENT | DIGCF_DEVICEINTERFACE);
+        handle = SetupDiGetClassDevs(ctypes.byref(GUID_XENBUS_IFACE), NULL, NULL, DIGCF_PRESENT | DIGCF_DEVICEINTERFACE);
 
         sdid = SP_DEVICE_INTERFACE_DATA()
         sdid.cbSize = ctypes.sizeof(sdid)
-        SetupDiEnumDeviceInterfaces(handle, NULL, ctypes.byref(GUID_XENBUS_IFACE), 0, ctype.byref(sdid))
+        if not SetupDiEnumDeviceInterfaces(handle, NULL, ctypes.byref(GUID_XENBUS_IFACE), 0, ctypes.byref(sdid)):
+            if ctypes.GetLastError() != ERROR_NO_MORE_ITEMS:
+                    raise ctypes.WinError()
 
         buf_len = DWORD()
-        SetupDiGetDeviceInterfaceDetail(handle, ctypes.byref(sdid), NULL, 0, ctypes.byref(buf_len), NULL);
+        if not SetupDiGetDeviceInterfaceDetail(handle, ctypes.byref(sdid), NULL, 0, ctypes.byref(buf_len), NULL):
+            if ctypes.GetLastError() != ERROR_INSUFFICIENT_BUFFER:
+                raise ctypes.WinError()
 
         # We didn't know how big to make the structure until buf_len is assigned...
         class SP_DEVICE_INTERFACE_DETAIL_DATA_A(ctypes.Structure):
@@ -360,7 +360,9 @@ get_xen_interface_path()
                 return "DevicePath:%s" % (self.DevicePath,)
 
         sdidd = SP_DEVICE_INTERFACE_DETAIL_DATA_A()
-        sdidd.cbSize = ctypes.sizeof(SP_DEVICE_INTERFACE_DETAIL_DATA_A);
+        sdidd.cbSize = ctypes.sizeof(ctypes.POINTER(SP_DEVICE_INTERFACE_DETAIL_DATA_A))
+        if not SetupDiGetDeviceInterfaceDetail(handle, ctypes.byref(sdid), ctypes.byref(sdidd), buf_len, NULL, NULL):
+            raise ctypes.WinError()
         self.path = ""+sdidd.DevicePath
 
         SetupDiDestroyDeviceInfoList(handle)

--- a/pyxs/connection.py
+++ b/pyxs/connection.py
@@ -211,10 +211,9 @@ class XenBusConnection(FileDescriptorConnection):
 _wmiSession = None
 
 class XenBusConnectionWin(FileDescriptorConnection):
-        
     session = None
     response_packet = None
-    
+
 
     def __init__(self):
         pass
@@ -226,7 +225,7 @@ class XenBusConnectionWin(FileDescriptorConnection):
 
     def connect(self, retry=0):
         global _wmiSession
-    
+
         # Create a WMI Session
         try:
             if not _wmiSession or retry > 0:
@@ -237,14 +236,14 @@ class XenBusConnectionWin(FileDescriptorConnection):
                 sleep(5)
                 self.connect(retry=(retry+1))
                 return
-            else: 
+            else:
                 raise PyXSError, None, sys.exc_info()[2]
-            
+
         try:
             sessions = _wmiSession.query("select * from XenProjectXenStoreSession where InstanceName = 'Xen Interface\Session_PyxsSession_0'")
         except Exception:
             sessions = []
-      
+
         if len(sessions) <= 0:
             session_name = "PyxsSession"
             session_id = xenStoreBase.AddSession(Id=session_name)[0]
@@ -261,7 +260,7 @@ class XenBusConnectionWin(FileDescriptorConnection):
 
 
     # Emulate sending the packet directly to the XenStore interface
-    # and store the result in response_packet 
+    # and store the result in response_packet
     def send(self, packet):
         global _wmiSession
 

--- a/pyxs/connection.py
+++ b/pyxs/connection.py
@@ -232,7 +232,7 @@ class XenBusConnectionWin(FileDescriptorConnection):
             if not _wmiSession or retry > 0:
                 _wmiSession = wmi.WMI(moniker="//./root/wmi", find_classes=False)
             xenStoreBase = _wmiSession.XenProjectXenStoreBase()[0]
-        except: # WMI can raise all sorts of exceptions
+        except Exception: # WMI can raise all sorts of exceptions
             if retry < 20:
                 sleep(5)
                 self.connect(retry=(retry+1))
@@ -242,7 +242,7 @@ class XenBusConnectionWin(FileDescriptorConnection):
             
         try:
             sessions = _wmiSession.query("select * from XenProjectXenStoreSession where InstanceName = 'Xen Interface\Session_PyxsSession_0'")
-        except:
+        except Exception:
             sessions = []
       
         if len(sessions) <= 0:
@@ -250,11 +250,11 @@ class XenBusConnectionWin(FileDescriptorConnection):
             session_id = xenStoreBase.AddSession(Id=session_name)[0]
             try:
                 sessions = _wmiSession.query("select * from XenProjectXenStoreSession where SessionId = {id}".format(id=session_id))
-            except:
+            except Exception:
                 sleep(0.5)
                 try:
                     sessions = _wmiSession.query("select * from XenProjectXenStoreSession where SessionId = {id}".format(id=session_id))
-                except: 
+                except Exception:
                     raise PyXSError, None, sys.exc_info()[2]
 
         self.session = sessions.pop()

--- a/pyxs/exceptions.py
+++ b/pyxs/exceptions.py
@@ -75,3 +75,6 @@ class UnexpectedPacket(ConnectionError):
     ``op = Op.READ`` the incoming packet is expected to have
     ``op = Op.READ`` as well.
     """
+
+class WindowsDriverError(PyXSError):
+    """Windows specific error when using native API to locate xenbus device"""

--- a/pyxs/helpers.py
+++ b/pyxs/helpers.py
@@ -45,17 +45,33 @@ if os.name in ["posix"]:
         return os.read(fd, length)
 
 elif os.name in ["nt"]:
+    from win32file import CreateFile, CloseHandle, ReadFile, WriteFile
+    from win32file import FILE_GENERIC_READ, FILE_GENERIC_WRITE, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL
+
     def osnmopen(path, *args):
-        pass
+        # CreateFile(path, FILE_GENERIC_READ|FILE_GENERIC_WRITE, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+        # http://docs.activestate.com/activepython/2.7/pywin32/win32file__CreateFile_meth.html
+        # PyHANDLE = CreateFile(fileName, desiredAccess , shareMode , attributes , CreationDisposition , flagsAndAttributes , hTemplateFile )
+        return CreateFile(path, FILE_GENERIC_READ|FILE_GENERIC_WRITE, 0, None, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, None)
 
     def osnmclose(fd):
-        pass
+        # http://docs.activestate.com/activepython/2.7/pywin32/win32file__CloseHandle_meth.html
+        # CloseHandle(handle)
+        CloseHandle(fd)
 
     def osnmread(fd, length):
-        pass
+        # ReadFile(handle, buf, 1024, &bytes_read, NULL)
+        # http://docs.activestate.com/activepython/2.7/pywin32/win32file__ReadFile_meth.html
+        # (int, string) = ReadFile(hFile, buffer/bufSize , ol )
+        (lread, data) = ReadFile(fd, length, None)
+        return data
 
     def osnmwrite(fd, data):
-        pass
+        # WriteFile(handle, buf, sizeof(*msg) + msg->len, &bytes_written, NULL)
+        # http://docs.activestate.com/activepython/2.7/pywin32/win32file__WriteFile_meth.html
+        # int, int = WriteFile(hFile, data , ol )
+        errCode, lwrite = WriteFile(fd, data, None)
+        return lwrite
 
 else:
     raise NotImplemented("No operating system fd interface defined")

--- a/pyxs/helpers.py
+++ b/pyxs/helpers.py
@@ -31,6 +31,36 @@ _codeerror = dict((message, code)
                   for code, message in errno.errorcode.items())
 
 
+if os.name in ["posix"]:
+    def osnmopen(path, *args):
+        return os.open(path, *args)
+
+    def osnmclose(fd):
+        os.close(fd)
+
+    def osnmwrite(fd, data):
+        return os.write(fd, data)
+
+    def osnmread(fd, length):
+        return os.read(fd, length)
+
+elif os.name in ["nt"]:
+    def osnmopen(path, *args):
+        pass
+
+    def osnmclose(fd):
+        pass
+
+    def osnmread(fd, length):
+        pass
+
+    def osnmwrite(fd, data):
+        pass
+
+else:
+    raise NotImplemented("No operating system fd interface defined")
+
+
 def writeall(fd, data):
     """Writes a data string to the file descriptor.
 
@@ -40,7 +70,7 @@ def writeall(fd, data):
     """
     length = len(data)
     while length:
-        length -= os.write(fd, data[-length:])
+        length -= osnmwrite(fd, data[-length:])
 
 
 def readall(fd, length):
@@ -51,7 +81,7 @@ def readall(fd, length):
     """
     chunks = []
     while length:
-        chunks.append(os.read(fd, length))
+        chunks.append(osnmread(fd, length))
         length -= len(chunks[-1])
     else:
         return b"".join(chunks)

--- a/tests.py
+++ b/tests.py
@@ -32,7 +32,7 @@ def test_packet():
 
     # b) invalid payload -- maximum size exceeded.
     with pytest.raises(InvalidPayload):
-        Packet(Op.DEBUG, "hello" * 4096, 0)
+        Packet(Op.CONTROL, "hello" * 4096, 0)
 
 
 # Helpers.
@@ -169,13 +169,13 @@ def test_client_execute_command():
 
     # a) arguments contain invalid characters.
     with pytest.raises(ValueError):
-        c.execute_command(Op.DEBUG, "\x07foo")
+        c.execute_command(Op.CONTROL, "\x07foo")
 
     # b) command validator fails.
-    c.COMMAND_VALIDATORS[Op.DEBUG] = lambda *args: False
+    c.COMMAND_VALIDATORS[Op.CONTROL] = lambda *args: False
     with pytest.raises(ValueError):
-        c.execute_command(Op.DEBUG, "foo")
-    c.COMMAND_VALIDATORS.pop(Op.DEBUG)
+        c.execute_command(Op.CONTROL, "foo")
+    c.COMMAND_VALIDATORS.pop(Op.CONTROL)
 
     # c) ``Packet`` constructor fails.
     with pytest.raises(InvalidPayload):
@@ -187,7 +187,7 @@ def test_client_execute_command():
 
     _old_recv = c.connection.recv
     # e) XenStore returns a packet with invalid operation in the header.
-    c.connection.recv = lambda *args: Packet(Op.DEBUG, "boo")
+    c.connection.recv = lambda *args: Packet(Op.CONTROL, "boo")
     with pytest.raises(UnexpectedPacket):
         c.execute_command(Op.READ, "/foo/bar")
     c.connection.recv = _old_recv


### PR DESCRIPTION
Hi,

This branch allows PyXS to work on Windows in combination with the GPLPV drivers.  The tested environment is:
Windows 2008R2
GPLPV 0.11.0.3
Python 2.7.6
pywin32-218.win-amd64-py2.7

The modified code was successfully tested on Windows and Linux with:

``` python
import os
import pyxs

if os.name in ["nt"]:
    xs = pyxs.Client(None)
elif os.name in ["posix"]:
    xs = pyxs.Client(xen_bus_path="/proc/xen/xenbus")

print xs.ls("/tools/data/vminfo")
print xs.read("vm")
```
