### PR TITLE
fix error handling in _XenBusTransport()

### DIFF
--- a/pyxs/connection.py
+++ b/pyxs/connection.py
@@ -199,7 +199,7 @@ class _XenBusTransport(object):
             self.fd = os.open(path, os.O_RDWR)
         except OSError as e:
             raise ConnectionError("error while opening {0!r}: {1}"
-                                  .format(self.path, e.args))
+                                  .format(path, e.args))
 
     def fileno(self):
         return self.fd


### PR DESCRIPTION
Fixes:
{noformat}
AttributeError: '_XenBusTransport' object has no attribute 'path'
{noformat}

on systems not running under Xen.

The error handling is still far from being perfect, though, as this still ends in an exception raised in a thread, which cannot be easily handled by the application.