### PR TITLE
Docs: point to correct code for decorated function

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -117,6 +117,7 @@ def linkcode_resolve(domain, info):
         import inspect
         import os
         import pyxs
+        obj = inspect.unwrap(obj)
         fn = inspect.getsourcefile(obj)
         fn = os.path.relpath(fn, os.path.dirname(pyxs.__file__))
         source, lineno = inspect.getsourcelines(obj)


### PR DESCRIPTION
This repairs a documentation link and fixes a [reproducibility issue](https://bugs.debian.org/966495).